### PR TITLE
Fix WiFi constant in fan example

### DIFF
--- a/examples/fan/main/main.c
+++ b/examples/fan/main/main.c
@@ -90,7 +90,7 @@ static void wifi_init() {
         };
 
         CHECK_ERROR(esp_wifi_set_mode(WIFI_MODE_STA));
-        CHECK_ERROR(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));
+        CHECK_ERROR(esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_config));
         CHECK_ERROR(esp_wifi_start());
 }
 


### PR DESCRIPTION
## Summary
- fix incorrect WiFi interface constant in fan example

## Testing
- `gcc -fsyntax-only -xc examples/fan/main/main.c` *(fails: esp_wifi.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6840405b869c83218461971be66e12bf