### PR TITLE
Fix ammonium typo

### DIFF
--- a/examples/Aubess_power_monitor_switch/main/custom_characteristics.h
+++ b/examples/Aubess_power_monitor_switch/main/custom_characteristics.h
@@ -39,7 +39,7 @@ extern homekit_characteristic_t custom_watt;
 
 #define HOMEKIT_CHARACTERISTIC_CUSTOM_AMMONIUM_LEVEL HOMEKIT_CUSTOM_UUID_DBB("F0000005")
 #define HOMEKIT_DECLARE_CHARACTERISTIC_CUSTOM_AMMONIUM_LEVEL(_value, ...) .type = HOMEKIT_CHARACTERISTIC_CUSTOM_AMMONIUM_LEVEL, \
-        .description = "Amonium Level", \
+        .description = "Ammonium Level", \
         .format = homekit_format_float, \
         .permissions = homekit_permissions_paired_read \
                        | homekit_permissions_notify, \


### PR DESCRIPTION
## Summary
- correct spelling for custom Ammonium characteristic

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684041f49c008321b8bf0bf03f715180