### PR TITLE
Remove old button.h comments

### DIFF
--- a/examples/programmable_switch/main/main.c
+++ b/examples/programmable_switch/main/main.c
@@ -35,7 +35,6 @@
 #include <homekit/homekit.h>
 #include <homekit/characteristics.h>
 
-// Removed: #include <button.h>
 
 // =======================
 // Error handling macros
@@ -161,8 +160,7 @@ void button_identify(homekit_value_t _value) {
 homekit_characteristic_t button_event =
     HOMEKIT_CHARACTERISTIC_(PROGRAMMABLE_SWITCH_EVENT, 0);
 
-// Original callback function that used to come from <button.h> logic
-// We'll define an enum for these events
+// Custom button event types
 typedef enum {
     button_event_single_press,
     button_event_double_press,
@@ -191,7 +189,7 @@ void button_callback(custom_button_event_t event, void *context) {
 }
 
 // ===============================================
-// Replace <button.h> with native ESP-IDF logic
+// Button implementation using ESP-IDF APIs
 // ===============================================
 
 // We'll track press times for single/double/long press
@@ -377,7 +375,5 @@ void app_main(void) {
     // Wi-Fi, GPIO, Button
     wifi_init();
     gpio_init();
-    custom_button_init();  // Replaces button_create(...)
-
-    // No more references to the old <button.h> library
+    custom_button_init();  // Initialize button handling
 }

--- a/examples/switch/main/main.c
+++ b/examples/switch/main/main.c
@@ -35,7 +35,6 @@
 #include <homekit/homekit.h>
 #include <homekit/characteristics.h>
 
-// Removed: #include <button.h>
 
 // Logging tag
 static const char *TAG = "HOMEKIT_SWITCH";
@@ -186,7 +185,7 @@ static void switch_on_callback(homekit_characteristic_t *_ch,
 // Single/Double/Long Press Logic
 // =============================
 
-// Define the event type that used to come from <button.h>
+// Define button event types
 typedef enum {
     button_event_single_press,
     button_event_double_press,
@@ -221,7 +220,7 @@ static void button_callback(button_event_t event, void *context) {
 }
 
 // =============================
-// Replacement for <button.h>
+// Button event handling
 // =============================
 static QueueHandle_t button_evt_queue = NULL;
 
@@ -405,7 +404,7 @@ void app_main(void) {
     // Setup Wi-Fi, I/O, and Button
     wifi_init();
     gpio_init();
-    button_init(); // Replaces the old code that used button_create(...)
+    button_init(); // Initialize button handling
 
     // Done. The rest is event-driven via ISR + tasks.
 }


### PR DESCRIPTION
## Summary
- clean up leftover references to the deprecated button library in `switch` example
- remove obsolete comments in `programmable_switch` example

## Testing
- `grep -nF "button.h" examples/programmable_switch/main/main.c`
- `grep -nF "button.h" examples/switch/main/main.c`


------
https://chatgpt.com/codex/tasks/task_e_684042a4291c8321ac416fd99cd8ce26