### PR TITLE
Add HSI to RGBW conversion unit test

### DIFF
--- a/components/hsi2rgbw/CMakeLists.txt
+++ b/components/hsi2rgbw/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "hsi2rgbw.c" INCLUDE_DIRS ".")

--- a/components/hsi2rgbw/hsi2rgbw.c
+++ b/components/hsi2rgbw/hsi2rgbw.c
@@ -1,0 +1,39 @@
+#include "hsi2rgbw.h"
+#include <math.h>
+
+void hsi2rgbw(float H, float S, float I, int *rgbw) {
+    int r = 0, g = 0, b = 0, w = 0;
+    float cos_h, cos_1047_h;
+
+    H = fmodf(H, 360.0f);
+    H = (float)M_PI * H / 180.0f;
+    S = fminf(fmaxf(S, 0.0f), 1.0f);
+    I = fminf(fmaxf(I, 0.0f), 1.0f);
+
+    if (H < 2.09439f) {
+        cos_h = cosf(H);
+        cos_1047_h = cosf(1.047196667f - H);
+        r = S * 255 * I / 3 * (1 + cos_h / cos_1047_h);
+        g = S * 255 * I / 3 * (1 + (1 - cos_h / cos_1047_h));
+        w = 255 * (1 - S) * I;
+    } else if (H < 4.188787f) {
+        H -= 2.09439f;
+        cos_h = cosf(H);
+        cos_1047_h = cosf(1.047196667f - H);
+        g = S * 255 * I / 3 * (1 + cos_h / cos_1047_h);
+        b = S * 255 * I / 3 * (1 + (1 - cos_h / cos_1047_h));
+        w = 255 * (1 - S) * I;
+    } else {
+        H -= 4.188787f;
+        cos_h = cosf(H);
+        cos_1047_h = cosf(1.047196667f - H);
+        b = S * 255 * I / 3 * (1 + cos_h / cos_1047_h);
+        r = S * 255 * I / 3 * (1 + (1 - cos_h / cos_1047_h));
+        w = 255 * (1 - S) * I;
+    }
+
+    rgbw[0] = r;
+    rgbw[1] = g;
+    rgbw[2] = b;
+    rgbw[3] = w;
+}

--- a/components/hsi2rgbw/hsi2rgbw.h
+++ b/components/hsi2rgbw/hsi2rgbw.h
@@ -1,0 +1,8 @@
+#pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
+void hsi2rgbw(float H, float S, float I, int *rgbw);
+#ifdef __cplusplus
+}
+#endif

--- a/examples/neopixel_rgbw_led_strip/main/CMakeLists.txt
+++ b/examples/neopixel_rgbw_led_strip/main/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(
     SRCS "main.c"
-    REQUIRES freertos esp_wifi nvs_flash driver esp32-homekit led_strip
+    REQUIRES freertos esp_wifi nvs_flash driver esp32-homekit led_strip hsi2rgbw
 )

--- a/examples/neopixel_rgbw_led_strip/main/idf_component.yml
+++ b/examples/neopixel_rgbw_led_strip/main/idf_component.yml
@@ -5,3 +5,5 @@ dependencies:
     version: ">=1.2.4"
   espressif/led_strip:
     version: ">=3.0.1"
+  hsi2rgbw:
+    path: ../../components/hsi2rgbw

--- a/examples/neopixel_rgbw_led_strip/main/main.c
+++ b/examples/neopixel_rgbw_led_strip/main/main.c
@@ -33,6 +33,7 @@
 #include <homekit/characteristics.h>
 #include <led_strip.h>
 #include <math.h>
+#include "hsi2rgbw.h"
 
 #define CHECK_ERROR(x) do { \
                 esp_err_t __err_rc = (x); \
@@ -102,42 +103,6 @@ static void wifi_init() {
         CHECK_ERROR(esp_wifi_start());
 }
 
-static void hsi2rgbw(float H, float S, float I, int* rgbw) {
-        int r = 0, g = 0, b = 0, w = 0;
-        float cos_h, cos_1047_h;
-
-        H = fmod(H, 360);
-        H = DEG_TO_RAD(H);
-        S = fminf(fmaxf(S, 0), 1);
-        I = fminf(fmaxf(I, 0), 1);
-
-        if (H < 2.09439) {
-                cos_h = cos(H);
-                cos_1047_h = cos(1.047196667 - H);
-                r = S * 255 * I / 3 * (1 + cos_h / cos_1047_h);
-                g = S * 255 * I / 3 * (1 + (1 - cos_h / cos_1047_h));
-                w = 255 * (1 - S) * I;
-        } else if (H < 4.188787) {
-                H -= 2.09439;
-                cos_h = cos(H);
-                cos_1047_h = cos(1.047196667 - H);
-                g = S * 255 * I / 3 * (1 + cos_h / cos_1047_h);
-                b = S * 255 * I / 3 * (1 + (1 - cos_h / cos_1047_h));
-                w = 255 * (1 - S) * I;
-        } else {
-                H -= 4.188787;
-                cos_h = cos(H);
-                cos_1047_h = cos(1.047196667 - H);
-                b = S * 255 * I / 3 * (1 + cos_h / cos_1047_h);
-                r = S * 255 * I / 3 * (1 + (1 - cos_h / cos_1047_h));
-                w = 255 * (1 - S) * I;
-        }
-
-        rgbw[0] = r;
-        rgbw[1] = g;
-        rgbw[2] = b;
-        rgbw[3] = w;
-}
 
 static void led_write(bool on) {
         if (led_strip) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.5)
+set(COMPONENTS main hsi2rgbw)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(hsi2rgbw_test)

--- a/tests/main/CMakeLists.txt
+++ b/tests/main/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "hsi2rgbw_test.c" REQUIRES unity hsi2rgbw)

--- a/tests/main/hsi2rgbw_test.c
+++ b/tests/main/hsi2rgbw_test.c
@@ -1,0 +1,50 @@
+#include <unity.h>
+#include "hsi2rgbw.h"
+
+static void test_primary_colors(void)
+{
+    int rgbw[4];
+
+    hsi2rgbw(0, 1, 1, rgbw);
+    TEST_ASSERT_EQUAL_INT(255, rgbw[0]);
+    TEST_ASSERT_EQUAL_INT(0, rgbw[1]);
+    TEST_ASSERT_EQUAL_INT(0, rgbw[2]);
+    TEST_ASSERT_EQUAL_INT(0, rgbw[3]);
+
+    hsi2rgbw(120, 1, 1, rgbw);
+    TEST_ASSERT_EQUAL_INT(0, rgbw[0]);
+    TEST_ASSERT_EQUAL_INT(255, rgbw[1]);
+    TEST_ASSERT_EQUAL_INT(0, rgbw[2]);
+    TEST_ASSERT_EQUAL_INT(0, rgbw[3]);
+
+    hsi2rgbw(240, 1, 1, rgbw);
+    TEST_ASSERT_EQUAL_INT(0, rgbw[0]);
+    TEST_ASSERT_EQUAL_INT(0, rgbw[1]);
+    TEST_ASSERT_EQUAL_INT(255, rgbw[2]);
+    TEST_ASSERT_EQUAL_INT(0, rgbw[3]);
+}
+
+static void test_white_and_dimming(void)
+{
+    int rgbw[4];
+
+    hsi2rgbw(0, 0, 1, rgbw);
+    TEST_ASSERT_EQUAL_INT(0, rgbw[0]);
+    TEST_ASSERT_EQUAL_INT(0, rgbw[1]);
+    TEST_ASSERT_EQUAL_INT(0, rgbw[2]);
+    TEST_ASSERT_EQUAL_INT(255, rgbw[3]);
+
+    hsi2rgbw(0, 1, 0.5, rgbw);
+    TEST_ASSERT_EQUAL_INT(127, rgbw[0]);
+    TEST_ASSERT_EQUAL_INT(0, rgbw[1]);
+    TEST_ASSERT_EQUAL_INT(0, rgbw[2]);
+    TEST_ASSERT_EQUAL_INT(0, rgbw[3]);
+}
+
+void app_main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_primary_colors);
+    RUN_TEST(test_white_and_dimming);
+    UNITY_END();
+}

--- a/tests/main/idf_component.yml
+++ b/tests/main/idf_component.yml
@@ -1,0 +1,5 @@
+dependencies:
+  idf:
+    version: ">=5.0"
+  hsi2rgbw:
+    path: ../../components/hsi2rgbw


### PR DESCRIPTION
## Summary
- make hsi2rgbw reusable as a component
- use the component in neopixel RGBW example
- add Unity based test for hsi2rgbw conversion

## Testing
- `idf.py test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684041f7e2488321b69f2cc56e521615