### PR TITLE
Fix rounding error in hsi2rgbw conversion

### DIFF
--- a/components/hsi2rgbw/hsi2rgbw.c
+++ b/components/hsi2rgbw/hsi2rgbw.c
@@ -13,23 +13,23 @@ void hsi2rgbw(float H, float S, float I, int *rgbw) {
     if (H < 2.09439f) {
         cos_h = cosf(H);
         cos_1047_h = cosf(1.047196667f - H);
-        r = S * 255 * I / 3 * (1 + cos_h / cos_1047_h);
-        g = S * 255 * I / 3 * (1 + (1 - cos_h / cos_1047_h));
-        w = 255 * (1 - S) * I;
+        r = (int)roundf(S * 255 * I / 3 * (1 + cos_h / cos_1047_h));
+        g = (int)roundf(S * 255 * I / 3 * (1 + (1 - cos_h / cos_1047_h)));
+        w = (int)roundf(255 * (1 - S) * I);
     } else if (H < 4.188787f) {
         H -= 2.09439f;
         cos_h = cosf(H);
         cos_1047_h = cosf(1.047196667f - H);
-        g = S * 255 * I / 3 * (1 + cos_h / cos_1047_h);
-        b = S * 255 * I / 3 * (1 + (1 - cos_h / cos_1047_h));
-        w = 255 * (1 - S) * I;
+        g = (int)roundf(S * 255 * I / 3 * (1 + cos_h / cos_1047_h));
+        b = (int)roundf(S * 255 * I / 3 * (1 + (1 - cos_h / cos_1047_h)));
+        w = (int)roundf(255 * (1 - S) * I);
     } else {
         H -= 4.188787f;
         cos_h = cosf(H);
         cos_1047_h = cosf(1.047196667f - H);
-        b = S * 255 * I / 3 * (1 + cos_h / cos_1047_h);
-        r = S * 255 * I / 3 * (1 + (1 - cos_h / cos_1047_h));
-        w = 255 * (1 - S) * I;
+        b = (int)roundf(S * 255 * I / 3 * (1 + cos_h / cos_1047_h));
+        r = (int)roundf(S * 255 * I / 3 * (1 + (1 - cos_h / cos_1047_h)));
+        w = (int)roundf(255 * (1 - S) * I);
     }
 
     rgbw[0] = r;


### PR DESCRIPTION
## Summary
- round floating point calculations in `hsi2rgbw` to avoid truncation

## Testing
- `cmake -S tests -B build` *(fails: include could not find requested file)*

------
https://chatgpt.com/codex/tasks/task_e_684b02f3a1748321bb713e16a3105aaa